### PR TITLE
Datastore tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://app.travis-ci.com/BookOps-CAT/NightShift.svg?branch=master)](https://app.travis-ci.com/BookOps-CAT/NightShift) [![Coverage Status](https://coveralls.io/repos/github/BookOps-CAT/NightShift/badge.svg?branch=main)](https://coveralls.io/github/BookOps-CAT/NightShift?branch=main) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://app.travis-ci.com/BookOps-CAT/NightShift.svg?branch=main)](https://app.travis-ci.com/BookOps-CAT/NightShift) [![Coverage Status](https://coveralls.io/repos/github/BookOps-CAT/NightShift/badge.svg?branch=main)](https://coveralls.io/github/BookOps-CAT/NightShift?branch=main) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # NightShift
 Copy cataloging bot.

--- a/nightshift/datastore.py
+++ b/nightshift/datastore.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+
+"""
+NightShift's database schema.
+
+
+dialect+driver://username:password@host:port/database
+# psycopg2
+engine = create_engine('postgresql+psycopg2://scott:tiger@localhost/mydatabase', client_encoding='utf8')
+"""
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    PickleType,
+    PrimaryKeyConstraint,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+
+Base = declarative_base()
+
+
+class Library(Base):
+    """
+    Library system.
+    """
+
+    __tablename__ = "library"
+
+    nid = Column(Integer, primary_key=True)
+    code = Column(String(3), unique=True)
+
+    def __repr__(self):
+        return f"<Library(nid='{self.nid}', code='{self.code}')>"
+
+
+class OutputFile(Base):
+    """
+    Output MARC file info.
+    """
+
+    __tablename__ = "output_file"
+    __table_args__ = (UniqueConstraint("handle", "libraryId"),)
+
+    nid = Column(Integer, primary_key=True)
+    libraryId = Column(Integer, ForeignKey("library.nid"), nullable=False)
+    handle = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.now())
+
+    def __repr__(self):
+        return (
+            f"<OutputFile(nid='{self.nid}', "
+            f"libraryId='{self.libraryId}', "
+            f"handle='{self.handle}', "
+            f"timestamp='{self.timestamp}')>"
+        )
+
+
+class Resource(Base):
+    """
+    Resource to be upgraded info.
+    """
+
+    __tablename__ = "resource"
+    __table_args__ = (
+        PrimaryKeyConstraint("sierraId", "libraryId"),
+        {},
+    )
+
+    sierraId = Column(Integer, nullable=False)
+    libraryId = Column(Integer, ForeignKey("library.nid"), nullable=False)
+    resourceCategoryId = Column(
+        Integer, ForeignKey("resource_category.nid"), nullable=False
+    )
+
+    archived = Column(Boolean, default=False)
+    bibDate = Column(Date)
+    author = Column(String(100, collation="uft8"))
+    title = Column(String(100, collation="utf8"))
+    pubDate = Column(String)
+
+    congressNumber = Column(String)
+    controlNumber = Column(String)
+    distributorNumber = Column(String)
+    otherNumber = Column(String)
+    outputId = Column(Integer, ForeignKey("output_file.nid"))
+    sourceId = Column(Integer, ForeignKey("source_file.nid"), nullable=False)
+    srcFieldsToKeep = Column(PickleType)
+    standardNumber = Column(String)
+    statusId = Column(Integer, ForeignKey("status.nid"), nullable=False)
+
+    oclcMatchNumber = Column(Integer)
+    upgradeTimestamp = Column(DateTime)
+
+    queries = relationship("WorldcatQuery", cascade="all, delete-orphan")
+
+    def __repr__(self):
+        return (
+            f"<Resource(sierraId='{self.sierraId}', libraryId='{self.libraryId}', "
+            f"sourceId='{self.sourceId}', "
+            f"resourceCategoryId='{self.resourceCategoryId}', "
+            f"archived='{self.archived}', "
+            f"bibDate='{self.bibDate}', "
+            f"author='{self.author}', "
+            f"title='{self.title}', "
+            f"pubDate='{self.pubDate}', "
+            f"controlNumber='{self.controlNumber}', "
+            f"congressNumber='{self.congressNumber}', "
+            f"standardNumber='{self.standardNumber}', "
+            f"distributorNumber='{self.distributorNumber}', "
+            f"statusId='{self.statusId}', "
+            f"outputId='{self.outputId}', "
+            f"oclcMatchNumber='{self.oclcMatchNumber}', "
+            f"upgradeTimestamp='{self.upgradeTimestamp}')>"
+        )
+
+
+class ResourceCategory(Base):
+    """
+    Resource Category. Example: ebook, fiction-gen, fiction-mystery.
+    """
+
+    __tablename__ = "resource_category"
+
+    nid = Column(Integer, primary_key=True)
+    code = Column(String, unique=True)
+    description = Column(String)
+
+    def __repr__(self):
+        return (
+            f"<ResourceCategory(nid='{self.nid}', "
+            f"code='{self.code}', "
+            f"description='{self.description}')>"
+        )
+
+
+class SourceFile(Base):
+    """
+    Source MARC file info.
+    """
+
+    __tablename__ = "source_file"
+    __table_args__ = (UniqueConstraint("handle", "libraryId"),)
+
+    nid = Column(Integer, primary_key=True)
+    libraryId = Column(Integer, ForeignKey("library.nid"), nullable=False)
+    handle = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.now())
+
+    def __repr__(self):
+        return (
+            f"<SourceFile(nid='{self.nid}', "
+            f"libraryId='{self.libraryId}', "
+            f"handle='{self.handle}', "
+            f"timestamp='{self.timestamp}')>"
+        )
+
+
+class Status(Base):
+    """
+    Stores different resource statuses
+    option examples: open, deleted, updated-bot, updated-staff
+    """
+
+    __tablename__ = "status"
+
+    nid = Column(Integer, primary_key=True)
+    name = Column(String(20), unique=True)
+    description = Column(String)
+
+    def __repr__(self):
+        return f"<Status(nid='{self.nid}', name='{self.name}', description='{self.description}')>"
+
+
+class WorldcatQuery(Base):
+    """
+    Metadata API responses.
+    """
+
+    __tablename__ = "worldcat_query"
+
+    nid = Column(Integer, primary_key=True)
+    resourceId = Column(Integer, ForeignKey("resource.sierraId"), nullable=False)
+    libraryId = Column(Integer, ForeignKey("library.nid"), nullable=False)
+    match = Column(Boolean, nullable=False)
+    responseCode = Column(Integer)
+    response = Column(PickleType)  # save as requests.Response object?
+
+    def __repr__(self):
+        return (
+            f"<WorldcatQuery(nid='{self.nid}', "
+            f"resouceId='{self.resourceId}', "
+            f"libraryId='{self.libraryId}', "
+            f"match='{self.match}', ",
+            f"responseCode='{self.responseCode}')>",
+        )

--- a/nightshift/datastore.py
+++ b/nightshift/datastore.py
@@ -168,7 +168,7 @@ class SourceFile(Base):
 class Status(Base):
     """
     Stores different resource statuses
-    option examples: open, deleted, updated-bot, updated-staff
+    option examples: open, deleted, upgraded-bot, upgraded-staff
     """
 
     __tablename__ = "status"
@@ -198,8 +198,8 @@ class WorldcatQuery(Base):
     def __repr__(self):
         return (
             f"<WorldcatQuery(nid='{self.nid}', "
-            f"resouceId='{self.resourceId}', "
+            f"resourceId='{self.resourceId}', "
             f"libraryId='{self.libraryId}', "
-            f"match='{self.match}', ",
-            f"responseCode='{self.responseCode}')>",
+            f"match='{self.match}', "
+            f"responseCode='{self.responseCode}')>"
         )

--- a/nightshift/datastore.py
+++ b/nightshift/datastore.py
@@ -83,7 +83,6 @@ class Resource(Base):
         Integer, ForeignKey("resource_category.nid"), nullable=False
     )
 
-    archived = Column(Boolean, default=False)
     bibDate = Column(Date)
     author = Column(String(collation="uft8"))
     title = Column(String(collation="utf8"))
@@ -93,10 +92,14 @@ class Resource(Base):
     controlNumber = Column(String)
     distributorNumber = Column(String)
     otherNumber = Column(String)
-    outputId = Column(Integer, ForeignKey("output_file.nid"))
     sourceId = Column(Integer, ForeignKey("source_file.nid"), nullable=False)
     srcFieldsToKeep = Column(PickleType)
     standardNumber = Column(String)
+
+    deleted = Column(Boolean, nullable=False, default=False)
+    deletedTimestamp = Column(DateTime)
+    oclcMatchNumber = Column(Integer)
+    outputId = Column(Integer, ForeignKey("output_file.nid"))
     status = Column(
         ENUM(
             "open",
@@ -107,8 +110,6 @@ class Resource(Base):
             name="status",
         )
     )
-
-    oclcMatchNumber = Column(Integer)
     upgradeTimestamp = Column(DateTime)
 
     queries = relationship("WorldcatQuery", cascade="all, delete-orphan")
@@ -118,7 +119,6 @@ class Resource(Base):
             f"<Resource(sierraId='{self.sierraId}', libraryId='{self.libraryId}', "
             f"sourceId='{self.sourceId}', "
             f"resourceCategoryId='{self.resourceCategoryId}', "
-            f"archived='{self.archived}', "
             f"bibDate='{self.bibDate}', "
             f"author='{self.author}', "
             f"title='{self.title}', "
@@ -128,6 +128,8 @@ class Resource(Base):
             f"standardNumber='{self.standardNumber}', "
             f"distributorNumber='{self.distributorNumber}', "
             f"status='{self.status}', "
+            f"deleted='{self.deleted}', "
+            f"deletedTimestamp='{self.deletedTimestamp}', "
             f"outputId='{self.outputId}', "
             f"oclcMatchNumber='{self.oclcMatchNumber}', "
             f"upgradeTimestamp='{self.upgradeTimestamp}')>"

--- a/poetry.lock
+++ b/poetry.lock
@@ -148,6 +148,14 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "psycopg2"
+version = "2.9.1"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -288,7 +296,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "2ed39d903199015db2215985df0b181dd1256fd7574ebd880ad8fb713c509c9e"
+content-hash = "6df513d911fe25b0f33210ee33d0bee0c9abf27e13c6cf116ee85616d59d99f8"
 
 [metadata.files]
 atomicwrites = [
@@ -440,6 +448,17 @@ platformdirs = [
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+psycopg2 = [
+    {file = "psycopg2-2.9.1-cp36-cp36m-win32.whl", hash = "sha256:7f91312f065df517187134cce8e395ab37f5b601a42446bdc0f0d51773621854"},
+    {file = "psycopg2-2.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:830c8e8dddab6b6716a4bf73a09910c7954a92f40cf1d1e702fb93c8a919cc56"},
+    {file = "psycopg2-2.9.1-cp37-cp37m-win32.whl", hash = "sha256:89409d369f4882c47f7ea20c42c5046879ce22c1e4ea20ef3b00a4dfc0a7f188"},
+    {file = "psycopg2-2.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7640e1e4d72444ef012e275e7b53204d7fab341fb22bc76057ede22fe6860b25"},
+    {file = "psycopg2-2.9.1-cp38-cp38-win32.whl", hash = "sha256:079d97fc22de90da1d370c90583659a9f9a6ee4007355f5825e5f1c70dffc1fa"},
+    {file = "psycopg2-2.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:2c992196719fadda59f72d44603ee1a2fdcc67de097eea38d41c7ad9ad246e62"},
+    {file = "psycopg2-2.9.1-cp39-cp39-win32.whl", hash = "sha256:2087013c159a73e09713294a44d0c8008204d06326006b7f652bef5ace66eebb"},
+    {file = "psycopg2-2.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:bf35a25f1aaa8a3781195595577fcbb59934856ee46b4f252f56ad12b8043bcf"},
+    {file = "psycopg2-2.9.1.tar.gz", hash = "sha256:de5303a6f1d0a7a34b9d40e4d3bef684ccc44a49bbe3eb85e3c0bffb4a131b7c"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 python = "^3.9"
 pymarc = "^4.1.1"
 SQLAlchemy = "^1.4.23"
+psycopg2 = "^2.9.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from nightshift.datastore import (
+    SourceFile,
+    Library,
+    OutputFile,
+    Resource,
+    ResourceCategory,
+)
+
+
+def test_Library_tbl_repr():
+    assert str(Library(nid=1, code="foo")) == "<Library(nid='1', code='foo')>"
+
+
+def test_OutputFile_tbl_repr():
+    stamp = datetime.now()
+    assert (
+        str(OutputFile(nid=1, libraryId=2, handle="foo.mrc", timestamp=stamp))
+        == f"<OutputFile(nid='1', libraryId='2', handle='foo.mrc', timestamp='{stamp}')>"
+    )
+
+
+def test_Resource_tbl_repr():
+    stamp = datetime.now()
+    bibDate = stamp.date()
+    assert (
+        str(
+            Resource(
+                sierraId=1,
+                libraryId=2,
+                resourceCategoryId=3,
+                archived=False,
+                bibDate=bibDate,
+                author="foo",
+                title="spam",
+                pubDate="2021",
+                congressNumber="0001",
+                controlNumber="0002",
+                distributorNumber="0003",
+                otherNumber="0004",
+                outputId=None,
+                sourceId=5,
+                srcFieldsToKeep=None,
+                standardNumber="0005",
+                statusId=6,
+                oclcMatchNumber=None,
+                upgradeTimestamp=stamp,
+            )
+        )
+        == f"<Resource(sierraId='1', libraryId='2', sourceId='5', resourceCategoryId='3', archived='False', bibDate='{bibDate}', author='foo', title='spam', pubDate='2021', controlNumber='0002', congressNumber='0001', standardNumber='0005', distributorNumber='0003', statusId='6', outputId='None', oclcMatchNumber='None', upgradeTimestamp='{stamp}')>"
+    )
+
+
+def test_ResourceCategory_tbl_repr():
+    assert (
+        str(ResourceCategory(nid=1, code="foo", description="spam"))
+        == "<ResourceCategory(nid='1', code='foo', description='spam')>"
+    )
+
+
+def test_SourceFile_tbl_repr():
+    stamp = datetime.now()
+    assert (
+        str(SourceFile(nid=1, libraryId=2, handle="foo.mrc", timestamp=stamp))
+        == f"<SourceFile(nid='1', libraryId='2', handle='foo.mrc', timestamp='{stamp}')>"
+    )

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -7,6 +7,8 @@ from nightshift.datastore import (
     OutputFile,
     Resource,
     ResourceCategory,
+    Status,
+    WorldcatQuery,
 )
 
 
@@ -65,4 +67,33 @@ def test_SourceFile_tbl_repr():
     assert (
         str(SourceFile(nid=1, libraryId=2, handle="foo.mrc", timestamp=stamp))
         == f"<SourceFile(nid='1', libraryId='2', handle='foo.mrc', timestamp='{stamp}')>"
+    )
+
+
+def test_Status_tbl_repr():
+    assert (
+        str(
+            Status(
+                nid=1,
+                name="upgraded-staff",
+                description="Upgraded inhouse by staff before bot",
+            )
+        )
+        == "<Status(nid='1', name='upgraded-staff', description='Upgraded inhouse by staff before bot')>"
+    )
+
+
+def test_WorldcatQuery_tbl_repr():
+    assert (
+        str(
+            WorldcatQuery(
+                nid=1,
+                resourceId=2,
+                libraryId=1,
+                match=False,
+                responseCode="404",
+                response=None,
+            )
+        )
+        == "<WorldcatQuery(nid='1', resourceId='2', libraryId='1', match='False', responseCode='404')>"
     )

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -24,7 +24,7 @@ def test_OutputFile_tbl_repr():
 
 
 def test_Resource_tbl_repr():
-    stamp = datetime.now()
+    stamp = datetime.utcnow()
     bibDate = stamp.date()
     assert (
         str(
@@ -32,7 +32,6 @@ def test_Resource_tbl_repr():
                 sierraId=1,
                 libraryId=2,
                 resourceCategoryId=3,
-                archived=False,
                 bibDate=bibDate,
                 author="foo",
                 title="spam",
@@ -46,11 +45,13 @@ def test_Resource_tbl_repr():
                 srcFieldsToKeep=None,
                 standardNumber="0005",
                 status="open",
+                deleted=False,
+                deletedTimestamp=stamp,
                 oclcMatchNumber=None,
                 upgradeTimestamp=stamp,
             )
         )
-        == f"<Resource(sierraId='1', libraryId='2', sourceId='5', resourceCategoryId='3', archived='False', bibDate='{bibDate}', author='foo', title='spam', pubDate='2021', controlNumber='0002', congressNumber='0001', standardNumber='0005', distributorNumber='0003', status='open', outputId='None', oclcMatchNumber='None', upgradeTimestamp='{stamp}')>"
+        == f"<Resource(sierraId='1', libraryId='2', sourceId='5', resourceCategoryId='3', bibDate='{bibDate}', author='foo', title='spam', pubDate='2021', controlNumber='0002', congressNumber='0001', standardNumber='0005', distributorNumber='0003', status='open', deleted='False', deletedTimestamp='{stamp}', outputId='None', oclcMatchNumber='None', upgradeTimestamp='{stamp}')>"
     )
 
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -7,7 +7,6 @@ from nightshift.datastore import (
     OutputFile,
     Resource,
     ResourceCategory,
-    Status,
     WorldcatQuery,
 )
 
@@ -46,12 +45,12 @@ def test_Resource_tbl_repr():
                 sourceId=5,
                 srcFieldsToKeep=None,
                 standardNumber="0005",
-                statusId=6,
+                status="open",
                 oclcMatchNumber=None,
                 upgradeTimestamp=stamp,
             )
         )
-        == f"<Resource(sierraId='1', libraryId='2', sourceId='5', resourceCategoryId='3', archived='False', bibDate='{bibDate}', author='foo', title='spam', pubDate='2021', controlNumber='0002', congressNumber='0001', standardNumber='0005', distributorNumber='0003', statusId='6', outputId='None', oclcMatchNumber='None', upgradeTimestamp='{stamp}')>"
+        == f"<Resource(sierraId='1', libraryId='2', sourceId='5', resourceCategoryId='3', archived='False', bibDate='{bibDate}', author='foo', title='spam', pubDate='2021', controlNumber='0002', congressNumber='0001', standardNumber='0005', distributorNumber='0003', status='open', outputId='None', oclcMatchNumber='None', upgradeTimestamp='{stamp}')>"
     )
 
 
@@ -67,19 +66,6 @@ def test_SourceFile_tbl_repr():
     assert (
         str(SourceFile(nid=1, libraryId=2, handle="foo.mrc", timestamp=stamp))
         == f"<SourceFile(nid='1', libraryId='2', handle='foo.mrc', timestamp='{stamp}')>"
-    )
-
-
-def test_Status_tbl_repr():
-    assert (
-        str(
-            Status(
-                nid=1,
-                name="upgraded-staff",
-                description="Upgraded inhouse by staff before bot",
-            )
-        )
-        == "<Status(nid='1', name='upgraded-staff', description='Upgraded inhouse by staff before bot')>"
     )
 
 


### PR DESCRIPTION
Hi @mwbenowitz,

This is initial schema for bot's database. I'm expecting it will require some adjustments as we go, but I hope it is a OK start for now.

Considerations:
- must serve two library systems
- the bot will query Worldcat multiple times over a longer period of time: 1st query-immediately, 2nd query-after 1 month, 3rd query-3 months, then give up and archive/delete some data
- records can be upgraded/deleted by staff thus not requiring any action from the bot (any after 1st query) so the app needs to check Sierra if update is still required and record it
- database should be able to provide data for any statistical analysis in the future
- initially the bot will query only for full ebook records, but the process will be expanded into some print material categories - this complicates the tables a little bit

Records representation string was added for debugging and logging purposes.

I added column archived to Resource to indicate any bibs which queries have been deleted (old, irrelevant records). I'm expecting the cleanup will include emptying WorldcatQuery.response columns, but other data could stay for any statistical analysis in the future.

Looking forward to your review!
