### PR TITLE
Ils check fix

### DIFF
--- a/nightshift/comms/sierra_search_platform.py
+++ b/nightshift/comms/sierra_search_platform.py
@@ -123,8 +123,11 @@ class SearchResponse:
             # no results, treat as deleted
             return "staff_deleted"
         else:
-            if data["bs_deleted_in_sierra"]:
-                return "staff_deleted"
+            try:
+                if data["bs_deleted_in_sierra"]:
+                    return "staff_deleted"
+            except KeyError:
+                pass
             # if bib orignated from Worldcat asssume full bib
             if "ss_marc_tag_003" in data and data["ss_marc_tag_003"] == "OCoLC":
                 return "staff_enhanced"
@@ -324,9 +327,9 @@ class BplSolr(SolrSession):
                 response_fields=[
                     "id",
                     "suppressed",
-                    "deleted",
                     "call_number",
                     "ss_marc_tag_003",
+                    "bs_deleted_in_sierra",
                 ],
             )
             search_response = SearchResponse(sierraId, "BPL", response)

--- a/nightshift/comms/sierra_search_platform.py
+++ b/nightshift/comms/sierra_search_platform.py
@@ -329,9 +329,10 @@ class BplSolr(SolrSession):
                     "suppressed",
                     "call_number",
                     "ss_marc_tag_003",
-                    "bs_deleted_in_sierra",
+                    # "bs_deleted_in_sierra",
                 ],
             )
+            logger.debug(f"BPL Solr request ({response.status_code}): {response.url}.")
             search_response = SearchResponse(sierraId, "BPL", response)
 
             return search_response

--- a/nightshift/datastore_transactions.py
+++ b/nightshift/datastore_transactions.py
@@ -131,7 +131,7 @@ def init_db() -> None:
         session.close()
 
 
-def add_event(session: Session, resource: Resource, status: str) -> Optional[Event]:
+def add_event(session: Session, resource: Resource, status: str) -> Event:
     """
     Inserts an event row.
 
@@ -149,15 +149,17 @@ def add_event(session: Session, resource: Resource, status: str) -> Optional[Eve
     Returns:
         `nightshift.datastore.Event` instance
     """
-    instance = insert_or_ignore(
-        session,
-        Event,
+    instance = Event(
         libraryId=resource.libraryId,
         sierraId=resource.sierraId,
         bibDate=resource.bibDate,
         resourceCategoryId=resource.resourceCategoryId,
         status=status,
+        timestamp=datetime.utcnow(),
     )
+
+    session.add(instance)
+
     return instance
 
 

--- a/nightshift/datastore_transactions.py
+++ b/nightshift/datastore_transactions.py
@@ -405,6 +405,7 @@ def retrieve_open_older_resources(
         list of `Row` instances
     """
 
+    # select only resources which age is between minAge & maxAge
     subq = (
         session.query(Resource, func.max(WorldcatQuery.timestamp).label("last_query"))
         .join(WorldcatQuery)
@@ -414,11 +415,13 @@ def retrieve_open_older_resources(
             Resource.status == "open",
             Resource.oclcMatchNumber == None,
             Resource.bibDate > datetime.utcnow() - timedelta(days=maxAge),
+            Resource.bibDate < datetime.utcnow() - timedelta(days=minAge),
         )
         .group_by(Resource.nid)
         .subquery()
     )
 
+    # select resources with last query before minAge of the given period
     resources = (
         session.query(Resource)
         .join(subq, and_(Resource.nid == subq.c.nid))

--- a/nightshift/manager.py
+++ b/nightshift/manager.py
@@ -102,7 +102,7 @@ def process_resources() -> None:
             # search again older resources dropping any resources already enhanced
             # or deleted
             for res_category, res_cat_data in res_cat.items():
-                for ageMin, ageMax in res_cat_data.queryDays:
+                for age_min, age_max in res_cat_data.queryDays:
                     resources = retrieve_open_older_resources(
                         db_session,
                         lib_nid,

--- a/nightshift/tasks.py
+++ b/nightshift/tasks.py
@@ -120,10 +120,10 @@ class Tasks:
             if resource.status in ("staff_enhanced", "staff_deleted"):
                 add_event(self.db_session, resource, status=resource.status)
 
-        sierra_platform.close()
+            # persist changes
+            self.db_session.commit()
 
-        # persist changes
-        self.db_session.commit()
+        sierra_platform.close()
 
     def enhance_and_output_bibs(
         self, resource_category: str, resources: list[Resource]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -622,7 +622,6 @@ class MockSolrSessionResponseSuccess:
                         "id": "12234255",
                         "suppressed": True,
                         "deleted": False,
-                        "bs_deleted_in_sierra": False,
                         "call_number": "eBOOK",
                     }
                 ],

--- a/tests/unit/test_datastore_transactions.py
+++ b/tests/unit/test_datastore_transactions.py
@@ -488,74 +488,17 @@ def test_retrieve_open_matched_resources_with_full_bib_obtained(
 
 
 @pytest.mark.parametrize(
-    "bib_date,status,oclc_number,match,days_since_last_query,expectation",
+    "min_age,max_age,query_age,expectation",
     [
-        pytest.param(
-            datetime.utcnow() - timedelta(days=80),
-            "open",
-            None,
-            False,
-            31,
-            [1],
-            id="query needed",
-        ),
-        pytest.param(
-            datetime.utcnow() - timedelta(days=80),
-            "open",
-            None,
-            False,
-            15,
-            [],
-            id="already queried",
-        ),
-        pytest.param(
-            datetime.utcnow() - timedelta(days=80),
-            "open",
-            None,
-            False,
-            100,
-            [],
-            id="last query > maxAge",
-        ),
-        pytest.param(
-            datetime.utcnow() - timedelta(days=100),
-            "open",
-            None,
-            False,
-            31,
-            [],
-            id="too old resource",
-        ),
-        pytest.param(
-            datetime.utcnow() - timedelta(days=80),
-            "expired",
-            None,
-            False,
-            31,
-            [],
-            id="expired status",
-        ),
-        pytest.param(
-            datetime.utcnow() - timedelta(days=100),
-            "open",
-            "123",
-            True,
-            31,
-            [],
-            id="matched resource",
-        ),
+        pytest.param(30, 90, 25, [1], id="query needed"),
+        pytest.param(30, 90, 31, [], id="queried already"),
+        pytest.param(30, 70, 1, [], id="resource too old"),
     ],
 )
 def test_retrieve_open_older_resources(
-    test_session,
-    test_data_core,
-    bib_date,
-    status,
-    oclc_number,
-    match,
-    days_since_last_query,
-    expectation,
+    test_session, test_data_core, min_age, max_age, query_age, expectation
 ):
+    bib_date = datetime.utcnow() - timedelta(days=80)
 
     test_session.add(
         Resource(
@@ -566,20 +509,143 @@ def test_retrieve_open_older_resources(
             resourceCategoryId=1,
             title="TEST TITLE",
             sourceId=1,
-            oclcMatchNumber=oclc_number,
+            oclcMatchNumber=None,
+            status="open",
+            queries=[
+                WorldcatQuery(
+                    nid=1,
+                    resourceId=1,
+                    match=False,
+                    timestamp=bib_date + timedelta(days=query_age),
+                ),
+            ],
+        )
+    )
+    test_session.commit()
+
+    res = retrieve_open_older_resources(test_session, 1, 1, min_age, max_age)
+    assert [r.nid for r in res] == expectation
+
+
+def test_retrieve_open_older_resources_no_queries_performed(
+    test_session, test_data_core
+):
+    test_session.add(
+        Resource(
+            nid=1,
+            sierraId=22222222,
+            libraryId=1,
+            bibDate=datetime.utcnow() - timedelta(days=80),
+            resourceCategoryId=1,
+            title="TEST TITLE",
+            sourceId=1,
+            oclcMatchNumber=None,
+            status="open",
+        )
+    )
+    test_session.commit()
+
+    res = retrieve_open_older_resources(test_session, 1, 1, 30, 90)
+    assert res == []
+
+
+@pytest.mark.parametrize(
+    "query_age,expectation",
+    [
+        pytest.param(91, [], id="queried already"),
+        pytest.param(80, [1], id="query needed"),
+    ],
+)
+def test_retrieve_open_older_resources_multiple_queries_performed(
+    test_session, test_data_core, query_age, expectation
+):
+    bib_date = datetime.utcnow() - timedelta(days=100)
+
+    test_session.add(
+        Resource(
+            nid=1,
+            sierraId=22222222,
+            libraryId=1,
+            bibDate=bib_date,
+            resourceCategoryId=1,
+            title="TEST TITLE",
+            sourceId=1,
+            oclcMatchNumber=None,
+            status="open",
+            queries=[
+                WorldcatQuery(
+                    nid=1,
+                    resourceId=1,
+                    match=False,
+                    timestamp=bib_date + timedelta(days=1),
+                ),
+                WorldcatQuery(
+                    nid=2,
+                    resourceId=1,
+                    match=False,
+                    timestamp=bib_date + timedelta(days=30),
+                ),
+                WorldcatQuery(
+                    nid=3,
+                    resourceId=1,
+                    match=True,
+                    timestamp=bib_date + timedelta(days=query_age),
+                ),
+            ],
+        )
+    )
+    test_session.commit()
+
+    res = retrieve_open_older_resources(test_session, 1, 1, 90, 180)
+    assert [r.nid for r in res] == expectation
+
+
+@pytest.mark.parametrize(
+    "lib_id,res_cat_id,status,oclc_match_no,max_age,expectation",
+    [
+        pytest.param(1, 1, "open", None, 50, [1], id="match"),
+        pytest.param(2, 1, "open", None, 50, [], id="wrong library"),
+        pytest.param(1, 2, "open", None, 50, [], id="wrong res category"),
+        pytest.param(1, 1, "staff_deleted", None, 50, [], id="wrong status"),
+        pytest.param(1, 1, "open", "1234", 50, [], id="wrong oclc # value"),
+        pytest.param(1, 1, "open", None, 120, [], id="wrong too old bib"),
+    ],
+)
+def test_retrieve_open_older_resources_invalid_resources(
+    test_session,
+    test_data_core,
+    lib_id,
+    res_cat_id,
+    status,
+    oclc_match_no,
+    max_age,
+    expectation,
+):
+    bib_date = datetime.utcnow() - timedelta(days=max_age)
+
+    test_session.add(
+        Resource(
+            nid=1,
+            sierraId=22222222,
+            libraryId=lib_id,
+            bibDate=bib_date,
+            resourceCategoryId=res_cat_id,
+            title="TEST TITLE",
+            sourceId=1,
+            oclcMatchNumber=oclc_match_no,
             status=status,
             queries=[
                 WorldcatQuery(
                     nid=1,
                     resourceId=1,
                     match=False,
-                    timestamp=datetime.now() - timedelta(days=200),
+                    timestamp=bib_date + timedelta(days=1),
                 ),
                 WorldcatQuery(
                     nid=2,
                     resourceId=1,
-                    match=match,
-                    timestamp=datetime.now() - timedelta(days=days_since_last_query),
+                    match=False,
+                    timestamp=bib_date + timedelta(days=20),
                 ),
             ],
         )

--- a/tests/unit/test_datastore_transactions.py
+++ b/tests/unit/test_datastore_transactions.py
@@ -12,6 +12,7 @@ from nightshift.constants import RESOURCE_CATEGORIES
 
 from nightshift.datastore import (
     Base,
+    Event,
     Library,
     Resource,
     ResourceCategory,
@@ -112,6 +113,17 @@ def test_add_event(test_session, test_data_rich):
     assert event.bibDate == resource.bibDate
     assert event.resourceCategoryId == resource.resourceCategoryId
     assert event.status == "expired"
+
+
+def test_add_event_always_insert(test_session, test_data_rich):
+    resource = test_session.query(Resource).where(Resource.nid == 1).one()
+    event1 = add_event(test_session, resource, status="expired")
+    event2 = add_event(test_session, resource, status="expired")
+    test_session.commit()
+
+    results = test_session.query(Event).all()
+
+    assert len(results) == 2
 
 
 def test_add_output_file(test_session, test_data_core):

--- a/tests/unit/test_sierra_search_platform.py
+++ b/tests/unit/test_sierra_search_platform.py
@@ -189,6 +189,23 @@ class TestSearchResponse:
         }
         assert sr._determine_bpl_bib_status() == expectation
 
+    def test_determine_bpl_bib_status_no_bs_deleted_in_sierr_field(self):
+        response = MockSolrSessionResponseSuccess()
+        sr = SearchResponse(11111111, "BPL", response)
+        sr.json_response = {
+            "response": {
+                "numFound": 1,
+                "start": 0,
+                "numFoundExact": True,
+                "docs": [
+                    {
+                        "call_number": "eBOOK",
+                    }
+                ],
+            }
+        }
+        assert sr._determine_bpl_bib_status() == "open"
+
     @pytest.mark.parametrize(
         "library,response,expectation",
         [


### PR DESCRIPTION
Fixes:
+ Sierra state is checked correctly at appropriate time periods for each resource
+ identification of deleted BPL records in Solr

Changes:
+ events are always inserted
+ each Sierra state check is immediately persisted in db now